### PR TITLE
Make CGSolver scale-invariant and harden the direct solve

### DIFF
--- a/pygeoinf/linear_solvers.py
+++ b/pygeoinf/linear_solvers.py
@@ -150,7 +150,7 @@ class CholeskySolver(DirectLinearSolver):
         factor = cho_factor(matrix, overwrite_a=False)
 
         def solve_galerkin(c: np.ndarray) -> np.ndarray:
-            return cho_solve(factor, c)
+            return cho_solve(factor, c, check_finite=False)
 
         return self._build_inverse_operator(operator, solve_galerkin)
 
@@ -475,18 +475,20 @@ class CGSolver(IterativeLinearSolver):
             self._callback.reset()
 
         domain = operator.domain
-        x = domain.zero if x0 is None else domain.copy(x0)
-
-        r = domain.subtract(y, operator(x))
-        z = domain.copy(r) if preconditioner is None else preconditioner(r)
-        p = domain.copy(z)
-
         y_squared_norm = domain.squared_norm(y)
 
         if y_squared_norm == 0.0:
             return domain.zero
 
-        tol_sq = max(self._atol**2, (self._rtol**2) * y_squared_norm)
+        rhs_scale = np.sqrt(y_squared_norm)
+        y_scaled = domain.multiply(1.0 / rhs_scale, y)
+        x = domain.zero if x0 is None else domain.multiply(1.0 / rhs_scale, x0)
+
+        r = domain.subtract(y_scaled, operator(x))
+        z = domain.copy(r) if preconditioner is None else preconditioner(r)
+        p = domain.copy(z)
+
+        tol_sq = max((self._atol / rhs_scale) ** 2, self._rtol**2)
 
         maxiter = self._maxiter if self._maxiter is not None else 10 * domain.dim
 
@@ -525,7 +527,7 @@ class CGSolver(IterativeLinearSolver):
         if hasattr(self._callback, "finalize") and callable(self._callback.finalize):
             self._callback.finalize()
 
-        return x
+        return domain.multiply(rhs_scale, x)
 
 
 class MinResSolver(IterativeLinearSolver):

--- a/tests/test_linear_solvers.py
+++ b/tests/test_linear_solvers.py
@@ -282,6 +282,26 @@ def test_preconditioned_solve(solver, spd_operator: LinearOperator, x: np.ndarra
     assert np.allclose(result_adjoint, x, rtol=TEST_TOLERANCE, atol=TEST_TOLERANCE)
 
 
+def test_cg_solver_is_stable_under_large_rhs_scaling(
+    spd_operator: LinearOperator, x: np.ndarray
+):
+    """CG should be homogeneous for large right-hand-side amplitudes."""
+    solver = CGSolver(rtol=1e-10)
+    inverse_op = solver(spd_operator)
+
+    scale = 1.0e14
+    b = spd_operator(x)
+    result = inverse_op(spd_operator.domain.multiply(scale, b))
+
+    assert np.all(np.isfinite(spd_operator.domain.to_components(result)))
+    assert np.allclose(
+        spd_operator.domain.multiply(1.0 / scale, result),
+        x,
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+
 # =============================================================================
 # MinRes Specific Tests
 # =============================================================================


### PR DESCRIPTION
- CGSolver: normalise the right-hand side by its norm before iterating and rescale the solution at the end, so the convergence tolerance no longer depends on the absolute magnitude of the RHS.
- CholeskySolver: pass check_finite=False to cho_solve.
- Add test_cg_solver_is_stable_under_large_rhs_scaling.