### PR TITLE
Matrix-free point evaluation, Nyquist convention fixes, and whitened model-space formalism

### DIFF
--- a/pygeoinf/inversion.py
+++ b/pygeoinf/inversion.py
@@ -23,6 +23,10 @@ from .forward_problem import LinearForwardProblem, ForwardProblem
 from .gaussian_measure import GaussianMeasure
 
 
+Formalism = Literal["model_space", "data_space", "whitened_model_space"]
+"""The algebraic spaces in which the normal equations can be assembled."""
+
+
 class Inversion:
     """
     A base class for inversion methods.
@@ -101,7 +105,7 @@ class LinearInversion(Inversion):
         forward_problem: LinearForwardProblem,
         /,
         *,
-        formalism: Literal["model_space", "data_space"] = "data_space",
+        formalism: Formalism = "data_space",
     ) -> None:
         """
         Initializes the LinearInversion class.
@@ -109,19 +113,22 @@ class LinearInversion(Inversion):
         Args:
             forward_problem: An instance of a linear forward problem.
             formalism: The algebraic space in which the normal equations are
-                assembled and solved. Must be 'model_space' or 'data_space'.
+                assembled and solved. Must be 'model_space', 'data_space', or
+                'whitened_model_space'.
         """
         if not isinstance(forward_problem, LinearForwardProblem):
             raise ValueError("Forward problem must be a LinearForwardProblem.")
         super().__init__(forward_problem)
 
-        if formalism not in ("model_space", "data_space"):
-            raise ValueError("formalism must be either 'model_space' or 'data_space'")
+        if formalism not in ("model_space", "data_space", "whitened_model_space"):
+            raise ValueError(
+                "formalism must be 'model_space', 'data_space', or 'whitened_model_space'"
+            )
 
         self._formalism = formalism
 
     @property
-    def formalism(self) -> Literal["model_space", "data_space"]:
+    def formalism(self) -> Formalism:
         """
         The algebraic space in which the normal equations are assembled and solved.
         """
@@ -149,9 +156,7 @@ class LinearInversion(Inversion):
         """
         return self.forward_problem.joint_measure(model_measure)
 
-    def with_formalism(
-        self, formalism: Literal["model_space", "data_space"]
-    ) -> LinearInversion:
+    def with_formalism(self, formalism: Formalism) -> LinearInversion:
         """
         Returns a new instance of the inversion using the specified formalism.
         """
@@ -165,7 +170,7 @@ class LinearInversion(Inversion):
         dense: bool = False,
         parallel: bool = False,
         n_jobs: int = -1,
-        formalism: Optional[Literal["model_space", "data_space"]] = None,
+        formalism: Optional[Formalism] = None,
     ) -> LinearInversion:
         """
         Constructs a parameterized surrogate of the linear inversion.
@@ -201,7 +206,7 @@ class LinearInversion(Inversion):
         dense: bool = False,
         parallel: bool = False,
         n_jobs: int = -1,
-        formalism: Optional[Literal["model_space", "data_space"]] = None,
+        formalism: Optional[Formalism] = None,
     ) -> LinearInversion:
         """
         Constructs a surrogate of the linear inversion using a reduced data space.

--- a/pygeoinf/linear_bayesian.py
+++ b/pygeoinf/linear_bayesian.py
@@ -6,8 +6,8 @@ than seeking a single deterministic "best-fit" solution, it aims to determine
 the full posterior probability distribution of the unknown model parameters
 given the observed data, prior knowledge, and noise statistics.
 
-A core feature of this module is its dual algebraic formalism, allowing users to
-optimize computational efficiency based on the problem geometry:
+A core feature of this module is its choice of algebraic formalism, allowing users
+to optimize computational efficiency based on the problem geometry:
 
 - **data_space**: Assembles the data-space normal operator (size M x M, where M is
   the data dimension).
@@ -20,6 +20,14 @@ optimize computational efficiency based on the problem geometry:
   Normal Operator: `N = Q^-1 + A* R^-1 A`
   Kalman Gain:     `K = N^-1 A* R^-1`
   Best suited for overdetermined problems (N << M).
+
+- **whitened_model_space**: Assembles the normal operator on the whitened model
+  space, i.e. the domain of the prior covariance factor `L` (where `Q = L L*`).
+  Normal Operator: `N = I + L* A* R^-1 A L`
+  Kalman Gain:     `K = L N^-1 L* A* R^-1`
+  Requires the prior covariance factor rather than the prior precision `Q^-1`.
+  Since `N` is an identity-plus-positive-semi-definite operator, its spectrum
+  is bounded below by one, making unpreconditioned iterative solvers effective.
 
 Key Classes
 -----------
@@ -37,7 +45,7 @@ import numpy as np
 import scipy.sparse as sps
 import scipy.sparse.linalg as splinalg
 
-from .inversion import LinearInversion
+from .inversion import LinearInversion, Formalism
 from .gaussian_measure import GaussianMeasure
 from .forward_problem import LinearForwardProblem
 from .linear_operators import (
@@ -78,7 +86,7 @@ class LinearBayesianInversion(LinearInversion):
         model_prior_measure: GaussianMeasure,
         /,
         *,
-        formalism: Literal["model_space", "data_space"] = "data_space",
+        formalism: Formalism = "data_space",
     ) -> None:
         """
         Initializes the linear Bayesian inversion problem.
@@ -88,13 +96,14 @@ class LinearBayesianInversion(LinearInversion):
                 containing the forward operator `A` and data error measure `R`.
             model_prior_measure: The prior Gaussian measure `Q` on the model space.
             formalism: The algebraic space in which the normal equations are
-                assembled and solved. Must be 'model_space' or 'data_space'.
-                Defaults to 'data_space'.
+                assembled and solved. Must be 'model_space', 'data_space', or
+                'whitened_model_space'. Defaults to 'data_space'.
 
         Raises:
             ValueError: If an invalid formalism string is provided, or if the
-                'model_space' formalism is selected but the necessary inverse
-                covariance operators (precision operators) are not set.
+                'model_space' or 'whitened_model_space' formalism is selected
+                but the necessary operators (precision operators, or the prior
+                covariance factor) are not set.
         """
         super().__init__(forward_problem, formalism=formalism)
         self._model_prior_measure: GaussianMeasure = model_prior_measure
@@ -111,16 +120,28 @@ class LinearBayesianInversion(LinearInversion):
                 raise ValueError(
                     "Data error inverse covariance must be set for model_space formalism."
                 )
+        elif self.formalism == "whitened_model_space":
+            if not self.model_prior_measure.covariance_factor_set:
+                raise ValueError(
+                    "Prior covariance factor must be set for whitened_model_space formalism."
+                )
+            if (
+                self.forward_problem.data_error_measure_set
+                and not self.forward_problem.data_error_measure.inverse_covariance_set
+            ):
+                raise ValueError(
+                    "Data error inverse covariance must be set for "
+                    "whitened_model_space formalism."
+                )
 
-    def with_formalism(
-        self, formalism: Literal["model_space", "data_space"]
-    ) -> LinearBayesianInversion:
+    def with_formalism(self, formalism: Formalism) -> LinearBayesianInversion:
         """
         Returns a new instance of the Bayesian inversion using the specified formalism.
 
         Args:
             formalism: The algebraic space in which the normal equations should be
-                assembled and solved. Must be 'model_space' or 'data_space'.
+                assembled and solved. Must be 'model_space', 'data_space', or
+                'whitened_model_space'.
 
         Returns:
             A new LinearBayesianInversion instance sharing the exact same forward
@@ -161,6 +182,9 @@ class LinearBayesianInversion(LinearInversion):
 
         For 'data_space': Returns `N = A Q A* + R`
         For 'model_space': Returns `N = Q^-1 + A* R^-1 A`
+        For 'whitened_model_space': Returns `N = I + L* A* R^-1 A L`, where `L`
+        is the prior covariance factor. This operator acts on the domain of `L`,
+        which need not coincide with the model space.
 
         Returns:
             A LinearOperator representing the normal equations matrix.
@@ -179,7 +203,7 @@ class LinearBayesianInversion(LinearInversion):
                     forward_operator @ model_prior_covariance @ forward_operator.adjoint
                 )
 
-        else:  # model_space
+        elif self.formalism == "model_space":
             prior_inv_cov = self.model_prior_measure.inverse_covariance
             if self.forward_problem.data_error_measure_set:
                 data_inv_cov = (
@@ -191,6 +215,21 @@ class LinearBayesianInversion(LinearInversion):
                 )
             else:
                 return prior_inv_cov + forward_operator.adjoint @ forward_operator
+
+        else:  # whitened_model_space
+            factor = self.model_prior_measure.covariance_factor
+            identity = factor.domain.identity_operator()
+            whitened_forward = forward_operator @ factor
+            if self.forward_problem.data_error_measure_set:
+                data_inv_cov = (
+                    self.forward_problem.data_error_measure.inverse_covariance
+                )
+                return (
+                    identity
+                    + whitened_forward.adjoint @ data_inv_cov @ whitened_forward
+                )
+            else:
+                return identity + whitened_forward.adjoint @ whitened_forward
 
     def _compute_data_residual(self, data: Vector) -> Vector:
         """
@@ -228,15 +267,19 @@ class LinearBayesianInversion(LinearInversion):
         if self.formalism == "data_space":
             # In data space, the RHS is exactly the shifted data residuals
             return shifted_data
+
+        # In model space, the RHS is projected back via A* R^-1
+        if self.forward_problem.data_error_measure_set:
+            data_inv_cov = self.forward_problem.data_error_measure.inverse_covariance
+            rhs = forward_operator.adjoint(data_inv_cov(shifted_data))
         else:
-            # In model space, the RHS is projected back via A* R^-1
-            if self.forward_problem.data_error_measure_set:
-                data_inv_cov = (
-                    self.forward_problem.data_error_measure.inverse_covariance
-                )
-                return forward_operator.adjoint(data_inv_cov(shifted_data))
-            else:
-                return forward_operator.adjoint(shifted_data)
+            rhs = forward_operator.adjoint(shifted_data)
+
+        if self.formalism == "model_space":
+            return rhs
+
+        # In the whitened model space, the RHS is further pulled back via L*
+        return self.model_prior_measure.covariance_factor.adjoint(rhs)
 
     def kalman_operator(
         self,
@@ -252,6 +295,7 @@ class LinearBayesianInversion(LinearInversion):
 
         For 'data_space': `K = Q A* (A Q A* + R)^-1`
         For 'model_space': `K = (Q^-1 + A* R^-1 A)^-1 A* R^-1`
+        For 'whitened_model_space': `K = L (I + L* A* R^-1 A L)^-1 L* A* R^-1`
 
         Args:
             solver: The LinearSolver used to invert the normal operator.
@@ -277,7 +321,7 @@ class LinearBayesianInversion(LinearInversion):
                 @ forward_operator.adjoint
                 @ inverse_normal_operator
             )
-        else:  # model_space
+        elif self.formalism == "model_space":
             if self.forward_problem.data_error_measure_set:
                 data_inv_cov = (
                     self.forward_problem.data_error_measure.inverse_covariance
@@ -285,6 +329,18 @@ class LinearBayesianInversion(LinearInversion):
                 return inverse_normal_operator @ forward_operator.adjoint @ data_inv_cov
             else:
                 return inverse_normal_operator @ forward_operator.adjoint
+        else:  # whitened_model_space
+            factor = self.model_prior_measure.covariance_factor
+            whitened_gain = (
+                factor @ inverse_normal_operator @ factor.adjoint
+            ) @ forward_operator.adjoint
+            if self.forward_problem.data_error_measure_set:
+                data_inv_cov = (
+                    self.forward_problem.data_error_measure.inverse_covariance
+                )
+                return whitened_gain @ data_inv_cov
+            else:
+                return whitened_gain
 
     # =========================================================================
     # Posterior Extraction
@@ -338,7 +394,7 @@ class LinearBayesianInversion(LinearInversion):
             covariance = model_prior_covariance - (
                 kalman_gain @ forward_operator @ model_prior_covariance
             )
-        else:  # model_space
+        elif self.formalism == "model_space":
             if self.forward_problem.data_error_measure_set:
                 data_inv_cov = (
                     self.forward_problem.data_error_measure.inverse_covariance
@@ -350,6 +406,17 @@ class LinearBayesianInversion(LinearInversion):
                 kalman_gain = inverse_normal_operator @ forward_operator.adjoint
             # Optimization: In model space, the inverted normal operator IS the posterior covariance
             covariance = inverse_normal_operator
+        else:  # whitened_model_space
+            factor = self.model_prior_measure.covariance_factor
+            # C_post = L (I + L* A* R^-1 A L)^-1 L*
+            covariance = factor @ inverse_normal_operator @ factor.adjoint
+            if self.forward_problem.data_error_measure_set:
+                data_inv_cov = (
+                    self.forward_problem.data_error_measure.inverse_covariance
+                )
+                kalman_gain = covariance @ forward_operator.adjoint @ data_inv_cov
+            else:
+                kalman_gain = covariance @ forward_operator.adjoint
 
         # 2. Compute Posterior Mean
         shifted_data = self._compute_data_residual(data)
@@ -514,6 +581,10 @@ class LinearBayesianInversion(LinearInversion):
         inversion:
             Misfit = <v, R^-1 v> - <A* R^-1 v, (Q^-1 + A* R^-1 A)^-1 A* R^-1 v>
 
+        The same identity holds in the 'whitened_model_space' formalism with
+        the whitened right-hand side `L* A* R^-1 v` and normal operator, since
+        `L (I + L* A* R^-1 A L)^-1 L* = (Q^-1 + A* R^-1 A)^-1`.
+
         Args:
             data: The observed data vector 'd'.
             solver: The LinearSolver used to invert the normal operator.
@@ -529,7 +600,6 @@ class LinearBayesianInversion(LinearInversion):
             raise ValueError("Data error measure must be set.")
 
         data_space = self.data_space
-        model_space = self.model_space
         R_measure = self.forward_problem.data_error_measure
 
         # 1. Compute the raw shifted data residual
@@ -549,10 +619,10 @@ class LinearBayesianInversion(LinearInversion):
             # Misfit = <v_data, (A Q A* + R)^-1 v_data>
             mahalanobis_term = data_space.inner_product(v_data, w)
         else:
-            # Woodbury optimization for model_space.
+            # Woodbury optimization for model_space / whitened_model_space.
             R_inv = R_measure.inverse_covariance
             misfit_base = data_space.inner_product(v_data, R_inv(v_data))
-            misfit_reduction = model_space.inner_product(rhs, w)
+            misfit_reduction = normal_op.domain.inner_product(rhs, w)
             mahalanobis_term = misfit_base - misfit_reduction
 
         return float(mahalanobis_term)
@@ -627,7 +697,7 @@ class LinearBayesianInversion(LinearInversion):
         self,
         /,
         *,
-        operator_type: Literal["data_space", "model_space"] = "data_space",
+        operator_type: Formalism = "data_space",
         size_estimate: int = 10,
         method: Literal["variable", "fixed"] = "variable",
         max_samples: Optional[int] = None,
@@ -643,12 +713,14 @@ class LinearBayesianInversion(LinearInversion):
         Stochastic Lanczos Quadrature (SLQ).
 
         This acts as a public interface for computing the log-determinant of
-        either the data-space normal operator (A Q A* + R) or the model-space
-        normal operator (Q^-1 + A* R^-1 A). It securely resolves the correct
+        the data-space normal operator (A Q A* + R), the model-space normal
+        operator (Q^-1 + A* R^-1 A), or the whitened model-space normal
+        operator (I + L* A* R^-1 A L). It securely resolves the correct
         algebraic space and delegates to the internal matrix-free SLQ engine.
 
         Args:
-            operator_type: The target normal operator ('data_space' or 'model_space').
+            operator_type: The target normal operator ('data_space',
+                'model_space', or 'whitened_model_space').
             size_estimate: Initial number of Hutchinson samples (probe vectors).
             method: 'variable' to sample until 'rtol' is met, 'fixed' otherwise.
             max_samples: Hard limit on the number of Hutchinson samples.
@@ -664,12 +736,8 @@ class LinearBayesianInversion(LinearInversion):
             float: The estimated log-determinant ln(|N|).
         """
         surrogate = self.with_formalism(operator_type)
-        space = (
-            surrogate.model_space
-            if operator_type == "model_space"
-            else surrogate.data_space
-        )
         op = surrogate.normal_operator
+        space = op.domain
 
         return self._trace_log_slq(
             op,
@@ -732,8 +800,9 @@ class LinearBayesianInversion(LinearInversion):
             float: The estimated log-evidence ln(p(d)).
 
         Raises:
-            ValueError: If the 'model_space' formalism is used but no data error measure
-                        has been set on the forward problem.
+            ValueError: If the 'model_space' or 'whitened_model_space' formalism
+                        is used but no data error measure has been set on the
+                        forward problem.
         """
         mahalanobis = self.mahalanobis_evidence_term(
             data, solver, preconditioner=preconditioner
@@ -756,16 +825,6 @@ class LinearBayesianInversion(LinearInversion):
                 operator_type="data_space", **slq_kwargs
             )
         else:
-            # By Sylvester's determinant identity:
-            # ln|N_d| = ln|N_m| + ln|Q| + ln|R|
-            log_det_Nm = self.estimate_log_determinant(
-                operator_type="model_space", **slq_kwargs
-            )
-
-            log_det_Q = self._trace_log_slq(
-                self.model_prior_measure.covariance, self.model_space, **slq_kwargs
-            )
-
             if not self.forward_problem.data_error_measure_set:
                 raise ValueError(
                     "Data error measure is required to compute log evidence."
@@ -777,7 +836,26 @@ class LinearBayesianInversion(LinearInversion):
                 **slq_kwargs,
             )
 
-            log_det = log_det_Nm + log_det_Q + log_det_R
+            if self.formalism == "model_space":
+                # By Sylvester's determinant identity:
+                # ln|N_d| = ln|N_m| + ln|Q| + ln|R|
+                log_det_Nm = self.estimate_log_determinant(
+                    operator_type="model_space", **slq_kwargs
+                )
+
+                log_det_Q = self._trace_log_slq(
+                    self.model_prior_measure.covariance, self.model_space, **slq_kwargs
+                )
+
+                log_det = log_det_Nm + log_det_Q + log_det_R
+            else:  # whitened_model_space
+                # By the Weinstein-Aronszajn determinant identity:
+                # ln|N_d| = ln|N_w| + ln|R|
+                log_det_Nw = self.estimate_log_determinant(
+                    operator_type="whitened_model_space", **slq_kwargs
+                )
+
+                log_det = log_det_Nw + log_det_R
 
         m = self.data_space.dim
         constant = m * np.log(2 * np.pi)
@@ -822,8 +900,8 @@ class LinearBayesianInversion(LinearInversion):
         if self.formalism != "data_space":
             raise ValueError(
                 "This custom preconditioner is mathematically derived for the "
-                "data-space normal operator (A Q A* + R) and cannot be used "
-                "with the model-space formalism."
+                "data-space normal operator (A Q A* + R) and can only be used "
+                "with the data-space formalism."
             )
 
         data_space = self.data_space
@@ -923,8 +1001,8 @@ class LinearBayesianInversion(LinearInversion):
         if self.formalism != "data_space":
             raise ValueError(
                 "This custom preconditioner is mathematically derived for the "
-                "data-space normal operator (A Q A* + R) and cannot be used "
-                "with the model-space formalism."
+                "data-space normal operator (A Q A* + R) and can only be used "
+                "with the data-space formalism."
             )
 
         forward_op = self.forward_problem.forward_operator
@@ -1359,15 +1437,16 @@ class LinearBayesianInversion(LinearInversion):
         dense: bool = False,
         parallel: bool = False,
         n_jobs: int = -1,
-        formalism: Optional[Literal["model_space", "data_space"]] = None,
+        formalism: Optional[Formalism] = None,
     ) -> LinearBayesianInversion:
         """
         Constructs a parameterized surrogate of the Bayesian inversion.
 
-        If the target formalism resolves to 'model_space' (which is typical for
-        parameterized inversions), the parameter prior's covariance matrix will
-        be automatically densified to explicitly compute the required precision
-        (inverse covariance) operator.
+        If the target formalism resolves to 'model_space' or
+        'whitened_model_space' (which is typical for parameterized inversions),
+        the parameter prior's covariance matrix will be automatically densified
+        to explicitly compute the required precision (inverse covariance)
+        operator and covariance factor.
 
         Args:
             parameterization: A LinearOperator mapping from the parameter
@@ -1402,7 +1481,7 @@ class LinearBayesianInversion(LinearInversion):
         )
 
         new_prior = parameter_prior
-        if dense or target_formalism == "model_space":
+        if dense or target_formalism in ("model_space", "whitened_model_space"):
             new_prior = new_prior.with_dense_covariance(
                 parallel=parallel, n_jobs=n_jobs
             )
@@ -1418,7 +1497,7 @@ class LinearBayesianInversion(LinearInversion):
         dense: bool = False,
         parallel: bool = False,
         n_jobs: int = -1,
-        formalism: Optional[Literal["model_space", "data_space"]] = None,
+        formalism: Optional[Formalism] = None,
     ) -> LinearBayesianInversion:
         """
         Constructs a surrogate of the Bayesian inversion using a reduced data space.
@@ -1447,7 +1526,7 @@ class LinearBayesianInversion(LinearInversion):
         )
 
         new_prior = self.model_prior_measure
-        if dense or target_formalism == "model_space":
+        if dense or target_formalism in ("model_space", "whitened_model_space"):
             new_prior = new_prior.with_dense_covariance(
                 parallel=parallel, n_jobs=n_jobs
             )

--- a/pygeoinf/linear_optimisation.py
+++ b/pygeoinf/linear_optimisation.py
@@ -86,6 +86,11 @@ class LinearLeastSquaresInversion(LinearInversion):
         Raises:
             ValueError: If an invalid formalism string is provided.
         """
+        if formalism == "whitened_model_space":
+            raise ValueError(
+                "The whitened_model_space formalism requires a prior measure and "
+                "is only available for Bayesian inversions."
+            )
         super().__init__(forward_problem, formalism=formalism)
 
         if (
@@ -582,6 +587,11 @@ class ConstrainedLinearLeastSquaresInversion(LinearInversion):
         Raises:
             ValueError: If an invalid formalism string is provided.
         """
+        if formalism == "whitened_model_space":
+            raise ValueError(
+                "The whitened_model_space formalism requires a prior measure and "
+                "is only available for Bayesian inversions."
+            )
         super().__init__(forward_problem, formalism=formalism)
 
         if (
@@ -805,6 +815,11 @@ class LinearMinimumNormInversion(LinearInversion):
             formalism: The algebraic space in which the normal equations are
                 assembled and solved. Defaults to 'data_space'.
         """
+        if formalism == "whitened_model_space":
+            raise ValueError(
+                "The whitened_model_space formalism requires a prior measure and "
+                "is only available for Bayesian inversions."
+            )
         super().__init__(forward_problem, formalism=formalism)
 
         if (
@@ -1066,6 +1081,11 @@ class ConstrainedLinearMinimumNormInversion(LinearInversion):
             formalism: The algebraic space in which the normal equations are
                 assembled and solved. Defaults to 'data_space'.
         """
+        if formalism == "whitened_model_space":
+            raise ValueError(
+                "The whitened_model_space formalism requires a prior measure and "
+                "is only available for Bayesian inversions."
+            )
         super().__init__(forward_problem, formalism=formalism)
 
         if (

--- a/pygeoinf/symmetric_space/circle.py
+++ b/pygeoinf/symmetric_space/circle.py
@@ -259,15 +259,29 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
         return (k / self.radius) ** 2
 
     def laplacian_eigenvector_squared_norm(self, k: int) -> float:
-        return 1.0 if k == 0 else 2.0
+        # The basis function for k = 0 is a constant of unit norm. For
+        # 0 < |k| < kmax a unit component stores a conjugate pair of modes,
+        # giving a basis function of squared norm 2. The Nyquist mode
+        # k = kmax is stored once (rfft keeps a single real coefficient),
+        # so its basis function has squared norm 1/2.
+        if k == 0:
+            return 1.0
+        if abs(k) == self.kmax:
+            return 0.5
+        return 2.0
 
     def laplacian_eigenvectors_at_point(self, theta: float) -> np.ndarray:
         k_vals = np.arange(self.kmax + 1)
         cos_terms = np.cos(k_vals * theta)
         sin_terms = np.sin(k_vals[1 : self.kmax] * theta)
+        # Mode multiplicity of each component: conjugate pairs count twice,
+        # while the constant and the (real-only) Nyquist mode count once.
+        weights = np.full(self.dim, 2.0)
+        weights[0] = 1.0
+        weights[self.kmax] = 1.0
         return (
-            self.metric
-            @ np.concatenate([cos_terms, -sin_terms])
+            weights
+            * np.concatenate([cos_terms, -sin_terms])
             / (np.sqrt(2 * np.pi * self.radius))
         )
 
@@ -316,9 +330,16 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
             k_min = min(self.kmax, target_degree)
             c_out[: k_min + 1] = c_in[: k_min + 1]
 
-            # 3. Enforce a strictly real Nyquist frequency when downsampling
-            if target_degree < self.kmax:
-                c_out[target_degree] = c_out[target_degree].real + 0j
+            # 3. Handle the Nyquist frequency. When upsampling, the domain's
+            # Nyquist mode (counted once) becomes an interior mode (counted
+            # twice with its conjugate): halve it so the function is
+            # preserved. When downsampling, an interior conjugate pair folds
+            # onto the codomain's strictly real Nyquist mode: keeping twice
+            # its real part gives the orthogonal projection.
+            if target_degree > self.kmax:
+                c_out[self.kmax] = 0.5 * c_in[self.kmax].real + 0j
+            elif target_degree < self.kmax:
+                c_out[target_degree] = 2.0 * c_in[target_degree].real + 0j
 
             # 4. Return to the spatial domain
             return codomain.from_coefficients(c_out)
@@ -330,9 +351,13 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
             k_min = min(self.kmax, target_degree)
             c_out[: k_min + 1] = c_in[: k_min + 1]
 
-            # The adjoint must mirror the forward map's Nyquist handling perfectly
-            if self.kmax < target_degree:
-                c_out[self.kmax] = c_out[self.kmax].real + 0j
+            # The adjoint must mirror the forward map's Nyquist handling:
+            # the adjoint of the halved embedding gathers both conjugate
+            # copies, and the adjoint of the projection is the embedding.
+            if target_degree > self.kmax:
+                c_out[self.kmax] = 2.0 * c_in[self.kmax].real + 0j
+            elif target_degree < self.kmax:
+                c_out[target_degree] = 0.5 * c_in[target_degree].real + 0j
 
             return self.from_coefficients(c_out)
 

--- a/pygeoinf/symmetric_space/circle.py
+++ b/pygeoinf/symmetric_space/circle.py
@@ -8,7 +8,57 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
 from pygeoinf.linear_operators import LinearOperator
+from pygeoinf.hilbert_space import EuclideanSpace
 from .symmetric_space import AbstractSymmetricLebesgueSpace, SymmetricSobolevSpace
+
+
+
+def _matrix_free_point_evaluation_1d(
+    space, layout, th: np.ndarray
+) -> LinearOperator:
+    """
+    Builds a matrix-free point-evaluation operator for a 1D Fourier space.
+
+    Internal helper shared by the circle and line Sobolev spaces. The
+    operator's action matches the dense matrix assembled by
+    `point_evaluation_operator` to machine precision, but only a thin
+    complex phase matrix of shape (n_points, kmax + 1) is stored.
+
+    Args:
+        space: The Hilbert space on which the operator is defined.
+        layout: The circle Lebesgue space providing the coefficient layout
+            and FFT conventions of `space`.
+        th: Circle angles of the evaluation points.
+
+    Returns:
+        LinearOperator: An operator from `space` to `EuclideanSpace(n_points)`.
+    """
+    kmax = layout.kmax
+    n_points = th.size
+
+    freqs = np.arange(kmax + 1, dtype=float)
+    phase = np.exp(1j * th[:, None] * freqs[None, :])
+
+    # interior frequencies stand in for the conjugate pair not stored by rfft
+    weights = np.full(kmax + 1, 2.0)
+    weights[0] = 1.0
+    weights[kmax] = 1.0
+
+    inv_grid_size = 1.0 / (2 * kmax)
+    adjoint_scale = inv_grid_size / layout.fft_factor
+    inverse_metric_values = np.reciprocal(space.metric_values)
+    codomain = EuclideanSpace(n_points)
+
+    def mapping(x):
+        coeff = rfft(x) * weights
+        return (phase @ coeff).real * inv_grid_size
+
+    def adjoint_mapping(y):
+        z = phase.conj().T @ y
+        components = layout._coefficient_to_component(z * weights) * adjoint_scale
+        return space.from_components(inverse_metric_values * components)
+
+    return LinearOperator(space, codomain, mapping, adjoint_mapping=adjoint_mapping)
 
 
 class Lebesgue(AbstractSymmetricLebesgueSpace):
@@ -679,6 +729,34 @@ class Sobolev(SymmetricSobolevSpace):
             power_of_two=power_of_two,
             safe=safe,
         )
+
+    def point_evaluation_operator(
+        self, points: List[Any], /, *, matrix_free: bool = False
+    ) -> LinearOperator:
+        """
+        Returns a linear operator that evaluates a function at a list of points.
+
+        Both implementations realise the same truncated Fourier interpolant
+        (including the Nyquist conventions of `dirac`) and give identical
+        results to machine precision.
+
+        Args:
+            points: A list of angles.
+            matrix_free: If True, the dense (n_points x dim) matrix is never
+                assembled row by row from `dirac`; the operator instead
+                stores a thin complex phase matrix and applies itself and
+                its adjoint with a single matrix product each. In 1D the
+                phase matrix occupies the same memory as the dense matrix,
+                so the benefit is faster construction, not storage.
+        """
+        if not matrix_free:
+            return super().point_evaluation_operator(points)
+
+        if self.safe and self.order <= self.spatial_dimension / 2:
+            raise NotImplementedError("Point evaluation is not defined on this space")
+
+        angles = np.asarray(points, dtype=float).ravel()
+        return _matrix_free_point_evaluation_1d(self, self.underlying_space, angles)
 
     # ---------------------------------------------- #
     #                   Properties                   #

--- a/pygeoinf/symmetric_space/line.py
+++ b/pygeoinf/symmetric_space/line.py
@@ -10,6 +10,7 @@ from pygeoinf.linear_operators import LinearOperator
 from .symmetric_space import AbstractSymmetricLebesgueSpace, SymmetricSobolevSpace
 from .circle import Lebesgue as CircleLebesgue
 from .circle import Sobolev as CircleSobolev
+from .circle import _matrix_free_point_evaluation_1d
 
 
 class Lebesgue(AbstractSymmetricLebesgueSpace):
@@ -621,6 +622,37 @@ class Sobolev(SymmetricSobolevSpace):
             power_of_two=power_of_two,
             safe=safe,
         )
+
+    def point_evaluation_operator(
+        self, points: List[Any], /, *, matrix_free: bool = False
+    ) -> LinearOperator:
+        """
+        Returns a linear operator that evaluates a function at a list of points.
+
+        Both implementations realise the same truncated Fourier interpolant
+        (including the Nyquist conventions of `dirac`) and give identical
+        results to machine precision.
+
+        Args:
+            points: A list of x-coordinates.
+            matrix_free: If True, the dense (n_points x dim) matrix is never
+                assembled row by row from `dirac`; the operator instead
+                stores a thin complex phase matrix and applies itself and
+                its adjoint with a single matrix product each. In 1D the
+                phase matrix occupies the same memory as the dense matrix,
+                so the benefit is faster construction, not storage.
+        """
+        if not matrix_free:
+            return super().point_evaluation_operator(points)
+
+        if self.safe and self.order <= self.spatial_dimension / 2:
+            raise NotImplementedError("Point evaluation is not defined on this space")
+
+        pts = np.asarray(points, dtype=float).ravel()
+        lebesgue = self.underlying_space
+        circle = lebesgue.circle_space
+        th = (pts - lebesgue.a + lebesgue.c) / circle.radius
+        return _matrix_free_point_evaluation_1d(self, circle, th)
 
     # ---------------------------------------------- #
     #                   Properties                   #

--- a/pygeoinf/symmetric_space/plane.py
+++ b/pygeoinf/symmetric_space/plane.py
@@ -10,6 +10,7 @@ from pygeoinf.linear_operators import LinearOperator
 from .symmetric_space import AbstractSymmetricLebesgueSpace, SymmetricSobolevSpace
 from .torus import Lebesgue as TorusLebesgue
 from .torus import Sobolev as TorusSobolev
+from .torus import _matrix_free_point_evaluation_2d
 
 
 class Lebesgue(AbstractSymmetricLebesgueSpace):
@@ -466,6 +467,41 @@ class Sobolev(SymmetricSobolevSpace):
         return cls.from_covariance(
             cls.sobolev_kernel(kernel_order, kernel_scale), order, scale, **kwargs
         )
+
+    def point_evaluation_operator(
+        self, points: List[Any], /, *, matrix_free: bool = False
+    ) -> LinearOperator:
+        """
+        Returns a linear operator that evaluates a function at a list of points.
+
+        Both implementations realise the same truncated Fourier interpolant
+        (including the Nyquist conventions of `dirac`) and give identical
+        results to machine precision.
+
+        Args:
+            points: A list of (x, y) coordinate pairs.
+            matrix_free: If True, the dense (n_points x dim) matrix is never
+                formed. The Fourier kernel separates as
+                e^{i(kx tx + ky ty)} = e^{i kx tx} e^{i ky ty}, so the
+                operator stores only two thin complex phase matrices and
+                applies itself and its adjoint with a single matrix product
+                each. Memory usage is O(n_points * kmax) instead of
+                O(n_points * kmax^2), and both construction and application
+                are substantially faster for large spaces.
+        """
+        if not matrix_free:
+            return super().point_evaluation_operator(points)
+
+        if self.safe and self.order <= self.spatial_dimension / 2:
+            raise NotImplementedError("Point evaluation is not defined on this space")
+
+        pts = np.asarray(points, dtype=float).reshape(-1, 2)
+        torus = self.underlying_space.torus_space
+        ax, _, cx = self.bounds_x
+        ay, _, cy = self.bounds_y
+        th_x = (pts[:, 0] - ax + cx) / torus.radius_x
+        th_y = (pts[:, 1] - ay + cy) / torus.radius_y
+        return _matrix_free_point_evaluation_2d(self, torus, th_x, th_y)
 
     # ---------------------------------------------- #
     #                   Properties                   #

--- a/pygeoinf/symmetric_space/torus.py
+++ b/pygeoinf/symmetric_space/torus.py
@@ -17,7 +17,78 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
 from pygeoinf.linear_operators import LinearOperator
+from pygeoinf.hilbert_space import EuclideanSpace
 from .symmetric_space import AbstractSymmetricLebesgueSpace, SymmetricSobolevSpace
+
+
+
+def _matrix_free_point_evaluation_2d(
+    space, layout, th_x: np.ndarray, th_y: np.ndarray
+) -> LinearOperator:
+    """
+    Builds a matrix-free point-evaluation operator for a 2D Fourier space.
+
+    Internal helper shared by the torus and plane Sobolev spaces. The
+    operator's action matches the dense NUDFT matrix assembled by
+    `point_evaluation_operator` to machine precision, but only two thin
+    complex phase matrices are stored: the separability of the Fourier
+    kernel, e^{i(kx tx + ky ty)} = e^{i kx tx} e^{i ky ty}, lets the
+    operator and its adjoint be applied with a single complex matrix
+    product each (BLAS level 3).
+
+    Args:
+        space: The Hilbert space on which the operator is defined.
+        layout: The torus Lebesgue space providing the coefficient layout
+            and FFT conventions of `space`.
+        th_x: Torus angles of the evaluation points in the x-direction.
+        th_y: Torus angles of the evaluation points in the y-direction.
+
+    Returns:
+        LinearOperator: An operator from `space` to `EuclideanSpace(n_points)`.
+    """
+    kmax = layout.kmax
+    two_k = 2 * kmax
+    n_points = th_x.size
+
+    # rfft2 row frequencies, with dirac's +kmax Nyquist convention
+    freqs_x = np.arange(two_k, dtype=float)
+    freqs_x[kmax + 1 :] -= two_k
+    freqs_y = np.arange(kmax + 1, dtype=float)
+
+    phase_x = np.exp(1j * th_x[:, None] * freqs_x[None, :])
+    phase_y = np.exp(1j * th_y[:, None] * freqs_y[None, :])
+
+    # interior ky columns stand in for the conjugate pair not stored by rfft2
+    weights = np.full(kmax + 1, 2.0)
+    weights[0] = 1.0
+    weights[kmax] = 1.0
+
+    inv_grid_size = 1.0 / (two_k * two_k)
+    adjoint_scale = inv_grid_size / layout.fft_factor
+    inverse_metric_values = np.reciprocal(space.metric_values)
+    codomain = EuclideanSpace(n_points)
+
+    def mapping(x):
+        coeff = rfft2(x)
+        cw = coeff * weights[None, :]
+        # ky = kmax column: keep the pure +(kx, +kmax) modes used by dirac;
+        # the rfft2 mirror rows of this column must not contribute
+        cw[1:kmax, kmax] = 2.0 * coeff[1:kmax, kmax]
+        cw[kmax + 1 :, kmax] = 0.0
+        g = phase_x @ cw
+        return np.einsum("ij,ij->i", g, phase_y).real * inv_grid_size
+
+    def adjoint_mapping(y):
+        # z[kx, ky] = sum_i y_i e^{-i(freqs_x[kx] th_x_i + ky th_y_i)}
+        z = phase_x.conj().T @ (y[:, None] * phase_y.conj())
+        # ky = 0 column: the +-kx conjugate partners are stored explicitly
+        z[1:kmax, 0] += np.conj(z[two_k - 1 : kmax : -1, 0])
+        zw = z * weights[None, :]
+        zw[1:kmax, kmax] = 2.0 * z[1:kmax, kmax]
+        components = layout._coefficient_to_component(zw) * adjoint_scale
+        return space.from_components(inverse_metric_values * components)
+
+    return LinearOperator(space, codomain, mapping, adjoint_mapping=adjoint_mapping)
 
 
 class Lebesgue(AbstractSymmetricLebesgueSpace):
@@ -820,6 +891,38 @@ class Sobolev(SymmetricSobolevSpace):
             max_degree=max_degree,
             power_of_two=power_of_two,
             safe=safe,
+        )
+
+    def point_evaluation_operator(
+        self, points: List[Any], /, *, matrix_free: bool = False
+    ) -> LinearOperator:
+        """
+        Returns a linear operator that evaluates a function at a list of points.
+
+        Both implementations realise the same truncated Fourier interpolant
+        (including the Nyquist conventions of `dirac`) and give identical
+        results to machine precision.
+
+        Args:
+            points: A list of (theta_x, theta_y) angle pairs.
+            matrix_free: If True, the dense (n_points x dim) matrix is never
+                formed. The Fourier kernel separates as
+                e^{i(kx tx + ky ty)} = e^{i kx tx} e^{i ky ty}, so the
+                operator stores only two thin complex phase matrices and
+                applies itself and its adjoint with a single matrix product
+                each. Memory usage is O(n_points * kmax) instead of
+                O(n_points * kmax^2), and both construction and application
+                are substantially faster for large spaces.
+        """
+        if not matrix_free:
+            return super().point_evaluation_operator(points)
+
+        if self.safe and self.order <= self.spatial_dimension / 2:
+            raise NotImplementedError("Point evaluation is not defined on this space")
+
+        angles = np.asarray(points, dtype=float).reshape(-1, 2)
+        return _matrix_free_point_evaluation_2d(
+            self, self.underlying_space, angles[:, 0], angles[:, 1]
         )
 
     @property

--- a/pygeoinf/symmetric_space/torus.py
+++ b/pygeoinf/symmetric_space/torus.py
@@ -308,7 +308,7 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
         phase = self._kx_freqs * tx + self._ky_freqs * ty
         vals = np.where(self._is_imag, -np.sin(phase), np.cos(phase))
         norm_factor = np.sqrt(4 * np.pi**2 * self.radius_x * self.radius_y)
-        return self.metric @ vals / norm_factor
+        return self._dirac_weights * vals / norm_factor
 
     def random_point(self) -> Tuple[float, float]:
         """Returns a random coordinate point within the Torus domain [0, 2π] x [0, 2π]."""
@@ -519,6 +519,7 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
         """Constructs mappings between 1D component indices and 2D wavevectors."""
         self._eigenvalues = np.zeros(dim)
         self._squared_norms = np.zeros(dim)
+        self._dirac_weights = np.zeros(dim)
         self._kx_freqs = np.zeros(dim)
         self._ky_freqs = np.zeros(dim)
         self._is_imag = np.zeros(dim, dtype=bool)
@@ -531,8 +532,18 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
             ky_freq = ky_idx
             eval_val = (kx_freq / self.radius_x) ** 2 + (ky_freq / self.radius_y) ** 2
 
+            # A paired component stores a conjugate pair of modes: its basis
+            # function has amplitude 2 (dirac weight) and squared norm 2. A
+            # real-only Nyquist mode is stored once: amplitude 1 and squared
+            # norm 1/2. The constant mode has amplitude 1 and unit norm.
+            if is_real_only:
+                squared_norm = 1.0 if kx_idx == 0 and ky_idx == 0 else 0.5
+            else:
+                squared_norm = 2.0
+
             self._eigenvalues[idx] = eval_val
-            self._squared_norms[idx] = 1.0 if is_real_only else 2.0
+            self._squared_norms[idx] = squared_norm
+            self._dirac_weights[idx] = 1.0 if is_real_only else 2.0
             self._kx_freqs[idx] = kx_freq
             self._ky_freqs[idx] = ky_freq
             self._is_imag[idx] = False
@@ -541,6 +552,7 @@ class Lebesgue(AbstractSymmetricLebesgueSpace):
             if not is_real_only:
                 self._eigenvalues[idx] = eval_val
                 self._squared_norms[idx] = 2.0
+                self._dirac_weights[idx] = 2.0
                 self._kx_freqs[idx] = kx_freq
                 self._ky_freqs[idx] = ky_freq
                 self._is_imag[idx] = True

--- a/tests/symmetric_space/test_matrix_free_point_evaluation.py
+++ b/tests/symmetric_space/test_matrix_free_point_evaluation.py
@@ -1,0 +1,104 @@
+"""
+Tests for the matrix-free point evaluation operators on the circle, line,
+torus and plane Sobolev spaces.
+
+The matrix-free operators must reproduce the dense operators built by
+`point_evaluation_operator` to machine precision, in both their forward
+and adjoint actions.
+"""
+
+import numpy as np
+import pytest
+
+from pygeoinf.symmetric_space.circle import Sobolev as CircleSobolev
+from pygeoinf.symmetric_space.line import Sobolev as LineSobolev
+from pygeoinf.symmetric_space.plane import Sobolev as PlaneSobolev
+from pygeoinf.symmetric_space.torus import Sobolev as TorusSobolev
+
+KMAX = 8
+ORDER = 2.0
+SCALE = 0.1
+N_POINTS = 7
+SEED = 20260716
+RTOL = 1e-10
+
+
+def _circle_case(rng):
+    space = CircleSobolev(KMAX, ORDER, SCALE)
+    points = list(rng.uniform(0.0, 2.0 * np.pi, N_POINTS))
+    return space, points
+
+
+def _line_case(rng):
+    space = LineSobolev(KMAX, ORDER, SCALE, a=-1.0, b=2.0)
+    points = list(rng.uniform(-1.0, 2.0, N_POINTS))
+    return space, points
+
+
+def _torus_case(rng):
+    space = TorusSobolev(KMAX, ORDER, SCALE)
+    points = [tuple(p) for p in rng.uniform(0.0, 2.0 * np.pi, (N_POINTS, 2))]
+    return space, points
+
+
+def _plane_case(rng):
+    space = PlaneSobolev(KMAX, ORDER, SCALE, ax=-1.0, bx=2.0, ay=0.5, by=3.0)
+    xs = rng.uniform(-1.0, 2.0, N_POINTS)
+    ys = rng.uniform(0.5, 3.0, N_POINTS)
+    return space, list(zip(xs, ys))
+
+
+CASES = {
+    "circle": _circle_case,
+    "line": _line_case,
+    "torus": _torus_case,
+    "plane": _plane_case,
+}
+
+
+@pytest.fixture(params=CASES.keys())
+def case(request):
+    rng = np.random.default_rng(SEED)
+    space, points = CASES[request.param](rng)
+    return space, points
+
+
+def _relative_error(a, b):
+    return np.linalg.norm(a - b) / np.linalg.norm(b)
+
+
+class TestMatrixFreePointEvaluation:
+    def test_forward_matches_dense(self, case):
+        space, points = case
+        op_dense = space.point_evaluation_operator(points)
+        op_free = space.point_evaluation_operator(points, matrix_free=True)
+
+        assert op_free.domain == op_dense.domain
+        assert op_free.codomain == op_dense.codomain
+
+        rng = np.random.default_rng(SEED + 1)
+        for _ in range(5):
+            u = space.from_components(rng.standard_normal(space.dim))
+            assert _relative_error(op_free(u), op_dense(u)) < RTOL
+
+    def test_adjoint_matches_dense(self, case):
+        space, points = case
+        op_dense = space.point_evaluation_operator(points)
+        op_free = space.point_evaluation_operator(points, matrix_free=True)
+
+        rng = np.random.default_rng(SEED + 2)
+        for _ in range(5):
+            y = rng.standard_normal(len(points))
+            u_free = op_free.adjoint(y)
+            u_dense = op_dense.adjoint(y)
+            assert (
+                _relative_error(
+                    space.to_components(u_free), space.to_components(u_dense)
+                )
+                < RTOL
+            )
+
+    def test_operator_axioms(self, case):
+        space, points = case
+        op_free = space.point_evaluation_operator(points, matrix_free=True)
+        op_free.check(n_checks=3)

--- a/tests/symmetric_space/test_nyquist_conventions.py
+++ b/tests/symmetric_space/test_nyquist_conventions.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for the Nyquist-mode conventions on the circle and torus.
+
+These pin down three facts that must hold simultaneously:
+
+1. The Lebesgue metric assigns each basis function its true L² norm,
+   including the real-only Nyquist modes (squared norm 1/2).
+2. Point evaluation (`dirac`) reproduces a function's grid values exactly,
+   including functions with Nyquist content.
+3. The degree transfer operator embeds a space isometrically into a finer
+   one (the Nyquist coefficient is halved as it becomes a conjugate pair).
+"""
+
+import numpy as np
+import pytest
+
+from pygeoinf.symmetric_space.circle import (
+    Lebesgue as CircleLebesgue,
+    Sobolev as CircleSobolev,
+)
+from pygeoinf.symmetric_space.torus import (
+    Lebesgue as TorusLebesgue,
+    Sobolev as TorusSobolev,
+)
+
+KMAX = 8
+
+
+class TestCircleNyquist:
+    def test_nyquist_metric_is_true_norm(self):
+        space = CircleLebesgue(KMAX, radius=1.3)
+        comp = np.zeros(space.dim)
+        comp[KMAX] = 1.0
+        u = space.from_components(comp)
+        # basis function is cos(kmax * theta) / sqrt(2 pi r): squared norm 1/2
+        assert space.inner_product(u, u) == pytest.approx(0.5, rel=1e-12)
+
+    def test_dirac_reproduces_grid_values(self):
+        space = CircleSobolev(KMAX, 2.0, 0.1)
+        rng = np.random.default_rng(42)
+        u = space.from_components(rng.standard_normal(space.dim))
+        values = np.asarray(u)
+        thetas = np.arange(2 * KMAX) * np.pi / KMAX
+        op = space.point_evaluation_operator(list(thetas))
+        np.testing.assert_allclose(op(u), values, rtol=1e-10, atol=1e-12)
+
+    def test_degree_transfer_is_isometric_embedding(self):
+        space = CircleLebesgue(KMAX)
+        fine = space.degree_transfer_operator(2 * KMAX)
+        rng = np.random.default_rng(43)
+        u = space.from_components(rng.standard_normal(space.dim))
+        v = fine(u)
+        assert fine.codomain.inner_product(v, v) == pytest.approx(
+            space.inner_product(u, u), rel=1e-12
+        )
+        # round trip: project back onto the coarse space
+        u_back = fine.adjoint(v)
+        np.testing.assert_allclose(
+            space.to_components(u_back), space.to_components(u), rtol=1e-10
+        )
+
+
+class TestTorusNyquist:
+    def test_corner_metric_is_true_norm(self):
+        space = TorusLebesgue(KMAX)
+        corners = [(KMAX, 0), (0, KMAX), (KMAX, KMAX)]
+        for kx, ky in corners:
+            (idx,) = [
+                i
+                for i in range(space.dim)
+                if space._kx_freqs[i] == kx
+                and space._ky_freqs[i] == ky
+                and not space._is_imag[i]
+            ]
+            assert space.metric_values[idx] == pytest.approx(0.5)
+        # constant mode keeps unit norm
+        assert space.metric_values[0] == pytest.approx(1.0)
+
+    def test_dirac_reproduces_grid_values(self):
+        space = TorusSobolev(KMAX, 2.0, 0.1)
+        rng = np.random.default_rng(44)
+        u = space.from_components(rng.standard_normal(space.dim))
+        values = np.asarray(u)
+        h = np.pi / KMAX
+        points = [(2 * h, 3 * h), (0.0, 0.0), (5 * h, 7 * h)]
+        expected = np.array([values[2, 3], values[0, 0], values[5, 7]])
+        op = space.point_evaluation_operator(points)
+        np.testing.assert_allclose(op(u), expected, rtol=1e-10, atol=1e-12)

--- a/tests/test_inversion.py
+++ b/tests/test_inversion.py
@@ -172,7 +172,7 @@ class TestLinearInversion:
         assert inv_model.formalism == "model_space"
 
         # Test validation
-        with pytest.raises(ValueError, match="formalism must be either"):
+        with pytest.raises(ValueError, match="formalism must be"):
             ConcreteLinearInversion(forward_problem_no_error, formalism="wrong_space")
 
     def test_base_parameterized_inversion_type(

--- a/tests/test_linear_bayesian.py
+++ b/tests/test_linear_bayesian.py
@@ -267,7 +267,7 @@ class TestBayesianSampling:
         """
         Tests that invalid formalisms and missing inverse covariances are correctly caught.
         """
-        with pytest.raises(ValueError, match="formalism must be either"):
+        with pytest.raises(ValueError, match="formalism must be"):
             LinearBayesianInversion(
                 forward_problem, model_prior_measure, formalism="spectral_space"
             )
@@ -1175,3 +1175,314 @@ class TestBayesianEvidence:
         sign, exact_log_det = np.linalg.slogdet(exact_normal_matrix)
 
         assert np.isclose(approx_log_det, exact_log_det, rtol=0.05)
+
+
+# =============================================================================
+# Tests for the Whitened Model-Space Formalism
+# =============================================================================
+
+
+@pytest.fixture
+def correlated_prior(forward_problem: LinearForwardProblem) -> GaussianMeasure:
+    """
+    Provides a correlated prior with a non-trivial covariance factor whose
+    domain is a EuclideanSpace distinct from the model space.
+    """
+    space = forward_problem.model_space
+    B = np.random.randn(space.dim, space.dim)
+    covariance_matrix = B @ B.T + 0.5 * np.eye(space.dim)
+    return GaussianMeasure.from_covariance_matrix(space, covariance_matrix)
+
+
+class TestWhitenedFormalism:
+    """Tests for the 'whitened_model_space' formalism."""
+
+    def test_normal_operator_structure(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+    ):
+        """
+        The whitened normal operator must equal I + L* A* R^-1 A L on the
+        domain of the prior covariance factor, with spectrum bounded below
+        by one.
+        """
+        inversion = LinearBayesianInversion(
+            forward_problem, correlated_prior, formalism="whitened_model_space"
+        )
+        normal_op = inversion.normal_operator
+        factor = correlated_prior.covariance_factor
+
+        assert normal_op.domain == factor.domain
+        assert normal_op.codomain == factor.domain
+
+        A = forward_problem.forward_operator.matrix(dense=True)
+        L = factor.matrix(dense=True)
+        R_inv = forward_problem.data_error_measure.inverse_covariance.matrix(
+            dense=True
+        )
+        expected = np.eye(L.shape[1]) + L.T @ A.T @ R_inv @ A @ L
+
+        actual = normal_op.matrix(dense=True)
+        assert np.allclose(actual, expected)
+
+        eigenvalues = np.linalg.eigvalsh(actual)
+        assert np.min(eigenvalues) >= 1.0 - 1e-10
+
+    def test_posterior_equivalence_with_other_formalisms(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+        data: np.ndarray,
+    ):
+        """
+        All three formalisms must produce the same posterior expectation and
+        covariance.
+        """
+        solver = CholeskySolver(galerkin=True)
+
+        posteriors = {}
+        for formalism in ("data_space", "model_space", "whitened_model_space"):
+            inversion = LinearBayesianInversion(
+                forward_problem, correlated_prior, formalism=formalism
+            )
+            posteriors[formalism] = inversion.model_posterior_measure(data, solver)
+
+        reference = posteriors["data_space"]
+        model_space = forward_problem.model_space
+        for formalism in ("model_space", "whitened_model_space"):
+            posterior = posteriors[formalism]
+            assert np.allclose(
+                model_space.to_components(posterior.expectation),
+                model_space.to_components(reference.expectation),
+                atol=1e-6,
+                rtol=1e-6,
+            )
+            assert np.allclose(
+                posterior.covariance.matrix(dense=True),
+                reference.covariance.matrix(dense=True),
+                atol=1e-6,
+                rtol=1e-6,
+            )
+
+    def test_kalman_operator_equivalence(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+        data: np.ndarray,
+    ):
+        """
+        The whitened Kalman gain must act identically to the data-space one.
+        """
+        solver = CholeskySolver(galerkin=True)
+
+        gain_data = LinearBayesianInversion(
+            forward_problem, correlated_prior, formalism="data_space"
+        ).kalman_operator(solver)
+        gain_whitened = LinearBayesianInversion(
+            forward_problem, correlated_prior, formalism="whitened_model_space"
+        ).kalman_operator(solver)
+
+        assert np.allclose(
+            gain_whitened(data), gain_data(data), atol=1e-6, rtol=1e-6
+        )
+
+    def test_mahalanobis_evidence_term_equivalence(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+        data: np.ndarray,
+    ):
+        """
+        The Woodbury-based Mahalanobis term must agree across formalisms.
+        """
+        solver = CholeskySolver(galerkin=True)
+
+        terms = [
+            LinearBayesianInversion(
+                forward_problem, correlated_prior, formalism=formalism
+            ).mahalanobis_evidence_term(data, solver)
+            for formalism in ("data_space", "model_space", "whitened_model_space")
+        ]
+
+        assert np.isclose(terms[1], terms[0], rtol=1e-6)
+        assert np.isclose(terms[2], terms[0], rtol=1e-6)
+
+    def test_determinant_identity(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+    ):
+        """
+        Validates the Weinstein-Aronszajn identity ln|N_d| = ln|N_w| + ln|R|
+        that the whitened log-evidence computation relies upon.
+        """
+        inv_data = LinearBayesianInversion(
+            forward_problem, correlated_prior, formalism="data_space"
+        )
+        inv_whitened = inv_data.with_formalism("whitened_model_space")
+
+        _, log_det_Nd = np.linalg.slogdet(inv_data.normal_operator.matrix(dense=True))
+        _, log_det_Nw = np.linalg.slogdet(
+            inv_whitened.normal_operator.matrix(dense=True)
+        )
+        _, log_det_R = np.linalg.slogdet(
+            forward_problem.data_error_measure.covariance.matrix(dense=True)
+        )
+
+        assert np.isclose(log_det_Nd, log_det_Nw + log_det_R, rtol=1e-8)
+
+    def test_estimate_log_determinant_whitened(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+    ):
+        """
+        The SLQ log-determinant of the whitened normal operator must match
+        the exact dense value.
+        """
+        inversion = LinearBayesianInversion(
+            forward_problem, correlated_prior, formalism="whitened_model_space"
+        )
+
+        dim = correlated_prior.covariance_factor.domain.dim
+        np.random.seed(42)
+        approx_log_det = inversion.estimate_log_determinant(
+            operator_type="whitened_model_space",
+            size_estimate=dim,
+            method="fixed",
+            lanczos_degree=dim,
+            lanczos_rtol=None,
+        )
+
+        _, exact_log_det = np.linalg.slogdet(
+            inversion.normal_operator.matrix(dense=True)
+        )
+        assert np.isclose(approx_log_det, exact_log_det, rtol=0.05)
+
+    def test_posterior_sampling_statistics(
+        self,
+        identity_problem: LinearForwardProblem,
+        standard_prior: GaussianMeasure,
+        r3,
+    ):
+        """
+        Randomize-then-optimize sampling under the whitened formalism must
+        reproduce the posterior statistics.
+        """
+        solver = CholeskySolver(galerkin=True)
+        data = r3.random()
+
+        inversion = LinearBayesianInversion(
+            identity_problem, standard_prior, formalism="whitened_model_space"
+        )
+        posterior = inversion.model_posterior_measure(data, solver)
+
+        assert posterior.sample_set, "Posterior should support sampling."
+
+        n_samples = 4000
+        samples = posterior.samples(n_samples)
+        sample_matrix = np.column_stack([r3.to_components(s) for s in samples])
+
+        true_mean = r3.to_components(posterior.expectation)
+        true_cov = posterior.covariance.matrix(dense=True)
+
+        assert np.allclose(np.mean(sample_matrix, axis=1), true_mean, atol=0.01)
+        assert np.allclose(np.cov(sample_matrix), true_cov, atol=0.01)
+
+    def test_validation_errors(
+        self,
+        forward_problem: LinearForwardProblem,
+        model_prior_measure: GaussianMeasure,
+    ):
+        """
+        Missing prior covariance factors or data error precisions must be
+        caught at initialization.
+        """
+        factorless_prior = GaussianMeasure(
+            covariance=model_prior_measure.covariance
+        )
+        with pytest.raises(ValueError, match="Prior covariance factor must be set"):
+            LinearBayesianInversion(
+                forward_problem, factorless_prior, formalism="whitened_model_space"
+            )
+
+        cov_only_error = GaussianMeasure(
+            covariance=forward_problem.data_error_measure.covariance
+        )
+        bad_fp = LinearForwardProblem(
+            forward_problem.forward_operator, data_error_measure=cov_only_error
+        )
+        with pytest.raises(
+            ValueError, match="Data error inverse covariance must be set"
+        ):
+            LinearBayesianInversion(
+                bad_fp, model_prior_measure, formalism="whitened_model_space"
+            )
+
+    def test_data_space_preconditioner_guards(
+        self,
+        forward_problem: LinearForwardProblem,
+        model_prior_measure: GaussianMeasure,
+    ):
+        """
+        Data-space-only preconditioners must reject the whitened formalism.
+        """
+        inversion = LinearBayesianInversion(
+            forward_problem, model_prior_measure, formalism="whitened_model_space"
+        )
+
+        with pytest.raises(
+            ValueError, match="mathematically derived for the data-space"
+        ):
+            inversion.diagonal_normal_preconditioner()
+
+        with pytest.raises(
+            ValueError, match="mathematically derived for the data-space"
+        ):
+            inversion.sparse_localized_preconditioner(interacting_blocks=[[0, 1]])
+
+    def test_parameterized_inversion_whitened(
+        self,
+        forward_problem: LinearForwardProblem,
+        correlated_prior: GaussianMeasure,
+        data: np.ndarray,
+    ):
+        """
+        Parameterized surrogates must support the whitened formalism, with the
+        pulled-back prior automatically densified to provide a factor.
+        """
+        model_space = forward_problem.model_space
+        parameter_space = EuclideanSpace(10)
+        parameterization = LinearOperator.from_matrix(
+            parameter_space,
+            model_space,
+            np.random.randn(model_space.dim, parameter_space.dim),
+        )
+
+        inv_data = LinearBayesianInversion(
+            forward_problem, correlated_prior, formalism="data_space"
+        )
+        sub_data = inv_data.parameterized_inversion(parameterization)
+        sub_whitened = inv_data.parameterized_inversion(
+            parameterization, formalism="whitened_model_space"
+        )
+
+        assert sub_whitened.formalism == "whitened_model_space"
+
+        solver = CholeskySolver(galerkin=True)
+        post_data = sub_data.model_posterior_measure(data, solver)
+        post_whitened = sub_whitened.model_posterior_measure(data, solver)
+
+        assert np.allclose(
+            parameter_space.to_components(post_whitened.expectation),
+            parameter_space.to_components(post_data.expectation),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        assert np.allclose(
+            post_whitened.covariance.matrix(dense=True),
+            post_data.covariance.matrix(dense=True),
+            atol=1e-6,
+            rtol=1e-6,
+        )

--- a/tests/test_linear_optimisation.py
+++ b/tests/test_linear_optimisation.py
@@ -141,9 +141,30 @@ class TestLinearLeastSquaresInversion:
         Tests that providing an invalid formalism string raises the appropriate error.
         """
         with pytest.raises(
-            ValueError, match="formalism must be either 'model_space' or 'data_space'"
+            ValueError, match="formalism must be"
         ):
             LinearLeastSquaresInversion(forward_problem, formalism="spectral_space")
+
+    def test_whitened_formalism_rejected(
+        self, forward_problem: LinearForwardProblem
+    ):
+        """
+        Tests that the Bayesian-only whitened_model_space formalism is rejected
+        by the optimisation-based inversion classes.
+        """
+        with pytest.raises(
+            ValueError, match="only available for Bayesian inversions"
+        ):
+            LinearLeastSquaresInversion(
+                forward_problem, formalism="whitened_model_space"
+            )
+
+        with pytest.raises(
+            ValueError, match="only available for Bayesian inversions"
+        ):
+            LinearMinimumNormInversion(
+                forward_problem, formalism="whitened_model_space"
+            )
 
     def test_woodbury_exact_equivalence(self, forward_problem: LinearForwardProblem):
         """


### PR DESCRIPTION
Three related changes (one commit each), developed while scaling Bayesian
inversions to large point-evaluation data sets:

## 1. Fix Nyquist mode conventions on circle and torus (18a54c9)

The Lebesgue metric on `circle`/`torus` over-weighted the real-only Nyquist
modes (squared norm 2 for circle k=kmax, 1 for torus corners; the correct
value is 1/2), and the metric-based 1D Dirac consequently evaluated twice the
Nyquist content.

- Squared norms at Nyquist corrected to 0.5.
- Dirac representations now use explicit mode-multiplicity weights
  (`_dirac_weights` on torus); 2D Dirac behaviour is unchanged.
- `degree_transfer_operator` on the circle handles Nyquist consistently:
  upsampling halves the coefficient (isometric embedding), downsampling keeps
  twice the real part (orthogonal projection = exact adjoint).
- `line`/`plane` inherit via delegation.
- Regression tests: `tests/symmetric_space/test_nyquist_conventions.py`.

Note: this marginally changes numerical results for fields with energy at
k = kmax.

## 2. Matrix-free point evaluation (e62a62b)

`point_evaluation_operator(points, matrix_free=True)` on the four Sobolev
classes (circle, line, torus, plane), mirroring the existing sphere API. The
2D implementation avoids materialising the (n_points × dim) dense matrix; in
1D the gain is construction speed only (documented as such).

Tests: `tests/symmetric_space/test_matrix_free_point_evaluation.py`
(forward + adjoint vs dense to <1e-10, operator axioms, all four spaces).

## 3. `formalism="whitened_model_space"` for linear Bayesian inversion (ed3a425)

A third formalism solving the whitened normal equations
N_w = I + L* A* R⁻¹ A L on the domain of the prior covariance factor L.
Requires the prior to have a covariance factor and R⁻¹ (weaker requirement
than `model_space`, which needs Q⁻¹). Posterior covariance is L N_w⁻¹ L*.
Because spec(N_w) ≥ 1, unpreconditioned CG behaves gracefully even when the
prior dominates far from the data.

- `log_evidence` uses ln|N_d| = ln|N_w| + ln|R| (Weinstein–Aronszajn).
- `estimate_log_determinant` accepts `operator_type="whitened_model_space"`.
- Parameterised/data-reduced inversions densify the prior for the whitened case.
- The `linear_optimisation` classes explicitly reject it (no prior).

Tests: `TestWhitenedFormalism` in `tests/test_linear_bayesian.py`
(three-formalism equivalence, spectrum structure, sampling statistics,
SLQ log-determinant, guards).

## Test status

Full suite: **969 passed, 7 skipped, 1 xfailed** (re-verified on the pushed HEAD).
