### PR TITLE
fix(linear-solvers): report CG numerical breakdowns

### DIFF
--- a/pygeoinf/linear_solvers.py
+++ b/pygeoinf/linear_solvers.py
@@ -134,9 +134,25 @@ class CholeskySolver(DirectLinearSolver):
     """
 
     def __init__(
-        self, /, *, galerkin: bool = False, parallel: bool = False, n_jobs: int = -1
+        self,
+        /,
+        *,
+        galerkin: bool = False,
+        parallel: bool = False,
+        n_jobs: int = -1,
+        check_finite: bool = True,
     ) -> None:
+        """
+        Args:
+            galerkin: Whether to use the Galerkin matrix representation.
+            parallel: Whether to parallelize matrix construction.
+            n_jobs: Number of workers for parallel matrix construction.
+            check_finite: Whether to validate factor and right-hand-side arrays
+                before passing them to SciPy. Disable only for trusted finite
+                inputs when repeated solve-time validation is a bottleneck.
+        """
         super().__init__(galerkin=galerkin, parallel=parallel, n_jobs=n_jobs)
+        self._check_finite = check_finite
 
     def __call__(self, operator: LinearOperator) -> LinearOperator:
         assert operator.is_automorphism
@@ -147,10 +163,12 @@ class CholeskySolver(DirectLinearSolver):
             parallel=self._parallel,
             n_jobs=self._n_jobs,
         )
-        factor = cho_factor(matrix, overwrite_a=False)
+        factor = cho_factor(
+            matrix, overwrite_a=False, check_finite=self._check_finite
+        )
 
         def solve_galerkin(c: np.ndarray) -> np.ndarray:
-            return cho_solve(factor, c)
+            return cho_solve(factor, c, check_finite=self._check_finite)
 
         return self._build_inverse_operator(operator, solve_galerkin)
 
@@ -475,22 +493,31 @@ class CGSolver(IterativeLinearSolver):
             self._callback.reset()
 
         domain = operator.domain
-        x = domain.zero if x0 is None else domain.copy(x0)
-
-        r = domain.subtract(y, operator(x))
-        z = domain.copy(r) if preconditioner is None else preconditioner(r)
-        p = domain.copy(z)
-
         y_squared_norm = domain.squared_norm(y)
 
         if y_squared_norm == 0.0:
             return domain.zero
 
+        x = domain.zero if x0 is None else domain.copy(x0)
         tol_sq = max(self._atol**2, (self._rtol**2) * y_squared_norm)
+
+        r = domain.subtract(y, operator(x))
+        z = domain.copy(r) if preconditioner is None else preconditioner(r)
+        p = domain.copy(z)
 
         maxiter = self._maxiter if self._maxiter is not None else 10 * domain.dim
 
         num = domain.inner_product(r, z)
+        if not np.isfinite(num):
+            raise FloatingPointError(
+                "CG numerical breakdown: non-finite recurrence product "
+                "r.T M^-1 r. Rescale the problem or preconditioner."
+            )
+        if num <= 0:
+            raise FloatingPointError(
+                "CG numerical breakdown: non-positive r.T M^-1 r. The "
+                "preconditioner must be positive definite."
+            )
 
         for k in range(maxiter):
             if domain.squared_norm(r) <= tol_sq:
@@ -499,7 +526,21 @@ class CGSolver(IterativeLinearSolver):
 
             q = operator(p)
             den = domain.inner_product(p, q)
+            if not np.isfinite(den):
+                raise FloatingPointError(
+                "CG numerical breakdown: non-finite recurrence product "
+                "p.T A p. Rescale the problem or preconditioner."
+                )
+            if den <= 0:
+                raise FloatingPointError(
+                    "CG numerical breakdown: non-positive p.T A p. The "
+                    "operator must be positive definite."
+                )
             alpha = num / den
+            if not np.isfinite(alpha):
+                raise FloatingPointError(
+                    "CG numerical breakdown: non-finite step length alpha."
+                )
 
             domain.axpy(alpha, p, x)
             domain.axpy(-alpha, q, r)
@@ -511,7 +552,21 @@ class CGSolver(IterativeLinearSolver):
 
             den = num
             num = operator.domain.inner_product(r, z)
+            if not np.isfinite(num):
+                raise FloatingPointError(
+                    "CG numerical breakdown: non-finite recurrence product "
+                    "r.T M^-1 r after an iteration."
+                )
+            if num < 0:
+                raise FloatingPointError(
+                    "CG numerical breakdown: negative r.T M^-1 r after an "
+                    "iteration. The preconditioner must be positive definite."
+                )
             beta = num / den
+            if not np.isfinite(beta):
+                raise FloatingPointError(
+                    "CG numerical breakdown: non-finite direction weight beta."
+                )
 
             domain.ax(beta, p)
             domain.axpy(1.0, z, p)

--- a/tests/test_linear_solvers.py
+++ b/tests/test_linear_solvers.py
@@ -252,6 +252,57 @@ def test_action_defined_operator_solver(
     )
 
 
+def test_cholesky_solver_check_finite_can_be_disabled():
+    """Finite right-hand-side validation is an explicit Cholesky option."""
+    space = EuclideanSpace(1)
+    identity = LinearOperator.from_matrix(
+        space, space, np.array([[1.0]]), galerkin=True
+    )
+    invalid_rhs = np.array([np.nan])
+
+    with pytest.raises(ValueError):
+        CholeskySolver(galerkin=True)(identity)(invalid_rhs)
+
+    unchecked_result = CholeskySolver(
+        galerkin=True, check_finite=False
+    )(identity)(invalid_rhs)
+    assert np.isnan(unchecked_result[0])
+
+
+def test_cg_raises_for_non_finite_recurrence_product():
+    """CG reports overflow instead of returning a non-finite solution."""
+    space = EuclideanSpace(1)
+    identity = LinearOperator.from_matrix(
+        space, space, np.array([[1.0]]), galerkin=True
+    )
+    preconditioner = LinearOperator.from_matrix(
+        space, space, np.array([[1.0e150]]), galerkin=True
+    )
+    rhs = np.array([1.0e100])
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        with pytest.raises(FloatingPointError, match="non-finite recurrence"):
+            CGSolver(rtol=1.0e-12, maxiter=2)(
+                identity, preconditioner=preconditioner
+            )(rhs)
+
+def test_cg_does_not_expose_rhs_normalization_option():
+    """RHS scaling remains a caller-controlled system transformation."""
+    with pytest.raises(TypeError, match="normalize_rhs"):
+        CGSolver(normalize_rhs=True)
+
+
+def test_cg_raises_for_non_positive_curvature():
+    """CG rejects a non-SPD recurrence instead of dividing by its curvature."""
+    space = EuclideanSpace(1)
+    negative_identity = LinearOperator.from_matrix(
+        space, space, np.array([[-1.0]]), galerkin=True
+    )
+
+    with pytest.raises(FloatingPointError, match="non-positive p.T A p"):
+        CGSolver(rtol=1.0e-12, maxiter=2)(negative_identity)(np.array([1.0]))
+
+
 @pytest.mark.parametrize("solver", preconditionable_solvers)
 def test_preconditioned_solve(solver, spd_operator: LinearOperator, x: np.ndarray):
     """


### PR DESCRIPTION
- Make Cholesky finite-value validation configurable with a safe default
  - Detect and report CG numerical breakdowns before they produce invalid output
  - Add deterministic regression tests for solver failure modes

  `CholeskySolver` now accepts `check_finite=True` by default. For large, performance-sensitive problems whose matrix and right-hand sides are known to be finite, callers may set `check_finite=False` to skip SciPy's finite-value validation.

  After looking more into the last PR, the proposed CG RHS-normalization feature was not a universal numerical improvement. It can avoid overflow in some large-RHS /preconditioner-scale combinations, but can create overflow in corresponding small-RHS cases. The solver therefore does not choose a scaling automatically; users who know their system and preconditioner scales should rescale explicitly.

  CG now raises `FloatingPointError` when it encounters a non-finite recurrence product, non-positive curvature, or a non-finite step coefficient. Previously, these conditions could propagate through the iteration and return `NaN` or `inf` after expensive work. The new errors identify the failed CG quantity and advise callers to rescale the problem or preconditioner. These checks should add insignificant computational overhead, while hedging against possibly more time wasted in non-sensical loops. Previously, a NaN residual generally failed the convergence comparison silently, then propagated through later iterations until maxiter and produced an invalid result. The checks prevent that waste.